### PR TITLE
Fix webgl2 float texture

### DIFF
--- a/examples/float_data_texture.html
+++ b/examples/float_data_texture.html
@@ -1,0 +1,68 @@
+<body>
+  <canvas id="canvas" width=1280 height=720></canvas>
+</body>
+
+<script type="module">
+  import { GLCat } from '../dist/glcat.module.js';
+  import {
+    TRIANGLE_STRIP_QUAD,
+    TRIANGLE_STRIP_QUAD_UV,
+    Vector3,
+  } from 'https://unpkg.com/@fms-cat/experimental@0.4.1/dist/fms-cat-experimental.module.min.js';
+
+  const canvas = document.getElementById( 'canvas' );
+  const gl = canvas.getContext( 'webgl2' );
+  const glCat = new GLCat( gl );
+
+  const vboQuad = glCat.createBuffer();
+  vboQuad.setVertexbuffer( new Float32Array( TRIANGLE_STRIP_QUAD ) );
+
+  const vboUv = glCat.createBuffer();
+  vboUv.setVertexbuffer( new Float32Array( TRIANGLE_STRIP_QUAD_UV ) );
+
+  const shaderVert = `attribute vec2 aVertex;
+attribute vec2 aUv;
+varying vec2 vUv;
+
+void main() {
+  vUv = aUv;
+  gl_Position = vec4( aVertex, 0.0, 1.0 );
+}
+`;
+
+  const shaderFrag = `precision highp float;
+
+varying vec2 vUv;
+uniform sampler2D sampler0;
+
+void main() {
+  gl_FragColor = texture2D( sampler0, vUv );
+}
+`;
+
+  const program = glCat.lazyProgram( shaderVert, shaderFrag );
+
+  const dataTextureArray = new Float32Array( 256 * 256 * 4 );
+  for ( let i = 0; i < 256 * 256 * 4; i ++ ) {
+    dataTextureArray[ i ] = Math.random() * 2.0 - 1.0;
+  }
+  const dataTexture = glCat.createTexture();
+  dataTexture.setTextureFromArray(
+    256,
+    256,
+    dataTextureArray,
+    { internalformat: gl.RGBA32F, format: gl.RGBA, type: gl.FLOAT }
+  );
+
+  program.attribute( 'aVertex', vboQuad, 2 );
+  program.attribute( 'aUv', vboUv, 2 );
+  program.uniformTexture( 'sampler0', dataTexture );
+
+  glCat.useProgram( program, () => {
+    gl.drawArrays( gl.TRIANGLE_STRIP, 0, 4 );
+  } );
+
+  program.dispose( true );
+  vboQuad.dispose();
+  vboUv.dispose();
+</script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -7,6 +7,7 @@
     <a href="./parallel_shader_compile.html">parallel_shader_compile</a> : Compile a shader asynchronously<br />
     <a href="./instancing.html">instancing</a> : Draw a lot of cube using instancing<br />
     <a href="./offscreen.html">offscreen</a> : Offscreen rendering + post effect using framebuffer<br />
+    <a href="./float_data_texture.html">float_data_texture.html</a> : Use float data texture<br />
     <a href="./webgl2.html">webgl2</a> : Try WebGL2<br />
     <a href="./webgl2_vao.html">webgl2_vao</a> : Plane using VAO<br />
     <a href="./webgl2_offscreen_msaa.html">webgl2_offscreen_msaa</a> : Multisample framebuffer<br />

--- a/src/GLCat.ts
+++ b/src/GLCat.ts
@@ -1,4 +1,4 @@
-import { GL_ARRAY_BUFFER, GL_BLEND, GL_COLOR_ATTACHMENT0, GL_COLOR_BUFFER_BIT, GL_DEPTH24_STENCIL8, GL_DEPTH_ATTACHMENT, GL_DEPTH_BUFFER_BIT, GL_DEPTH_COMPONENT16, GL_DEPTH_TEST, GL_DRAW_FRAMEBUFFER, GL_ELEMENT_ARRAY_BUFFER, GL_FRAGMENT_SHADER, GL_FRAMEBUFFER, GL_LEQUAL, GL_MAX_DRAW_BUFFERS, GL_NEAREST, GL_ONE_MINUS_SRC_ALPHA, GL_READ_FRAMEBUFFER, GL_RENDERBUFFER, GL_RGBA32F, GL_RGBA8, GL_SRC_ALPHA, GL_TEXTURE_2D, GL_TEXTURE_CUBE_MAP, GL_VERTEX_SHADER } from './GLConstants';
+import { GL_ARRAY_BUFFER, GL_BLEND, GL_COLOR_ATTACHMENT0, GL_COLOR_BUFFER_BIT, GL_DEPTH24_STENCIL8, GL_DEPTH_ATTACHMENT, GL_DEPTH_BUFFER_BIT, GL_DEPTH_COMPONENT16, GL_DEPTH_TEST, GL_DRAW_FRAMEBUFFER, GL_ELEMENT_ARRAY_BUFFER, GL_FLOAT, GL_FRAGMENT_SHADER, GL_FRAMEBUFFER, GL_LEQUAL, GL_MAX_DRAW_BUFFERS, GL_NEAREST, GL_ONE_MINUS_SRC_ALPHA, GL_READ_FRAMEBUFFER, GL_RENDERBUFFER, GL_RGBA, GL_RGBA32F, GL_RGBA8, GL_SRC_ALPHA, GL_TEXTURE_2D, GL_TEXTURE_CUBE_MAP, GL_VERTEX_SHADER } from './GLConstants';
 import { BindHelper } from './utils/BindHelper';
 import { GLCatBuffer } from './GLCatBuffer';
 import { GLCatErrors } from './GLCatErrors';
@@ -165,6 +165,38 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
    * Retrieve an extension.
    * If they is your precious one and you cannot live without him, turn on `throwIfNotFound`.
    */
+  public getExtension(
+    name: 'OES_texture_half_float',
+    throwIfNotFound?: false
+  ): OES_texture_half_float | null; // eslint-disable-line @typescript-eslint/camelcase
+  public getExtension(
+    name: 'OES_texture_half_float',
+    throwIfNotFound: true
+  ): OES_texture_half_float; // eslint-disable-line @typescript-eslint/camelcase
+  public getExtension(
+    name: 'OES_texture_half_float_linear',
+    throwIfNotFound?: false
+  ): OES_texture_half_float_linear | null; // eslint-disable-line @typescript-eslint/camelcase
+  public getExtension(
+    name: 'OES_texture_half_float_linear',
+    throwIfNotFound: true
+  ): OES_texture_half_float_linear; // eslint-disable-line @typescript-eslint/camelcase
+  public getExtension(
+    name: 'OES_texture_float',
+    throwIfNotFound?: false
+  ): OES_texture_float | null; // eslint-disable-line @typescript-eslint/camelcase
+  public getExtension(
+    name: 'OES_texture_float',
+    throwIfNotFound: true
+  ): OES_texture_float; // eslint-disable-line @typescript-eslint/camelcase
+  public getExtension(
+    name: 'OES_texture_float_linear',
+    throwIfNotFound?: false
+  ): OES_texture_float_linear | null; // eslint-disable-line @typescript-eslint/camelcase
+  public getExtension(
+    name: 'OES_texture_float_linear',
+    throwIfNotFound: true
+  ): OES_texture_float_linear; // eslint-disable-line @typescript-eslint/camelcase
   public getExtension(
     name: 'ANGLE_instanced_arrays',
     throwIfNotFound?: false
@@ -501,7 +533,12 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
       // == texture ================================================================================
       texture = this.createTexture();
       if ( isFloat ) {
-        texture.setTextureFromFloatArray( width, height, null );
+        texture.setTextureFromArray(
+          width,
+          height,
+          null,
+          { internalformat: GL_RGBA32F, format: GL_RGBA, type: GL_FLOAT }
+        );
       } else {
         texture.setTextureFromArray( width, height, null );
       }
@@ -611,7 +648,12 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
       for ( let i = 0; i < numBuffers; i ++ ) {
         const texture = this.createTexture();
         if ( isFloat ) {
-          texture.setTextureFromFloatArray( width, height, null );
+          texture.setTextureFromArray(
+            width,
+            height,
+            null,
+            { internalformat: GL_RGBA32F, format: GL_RGBA, type: GL_FLOAT }
+          );
         } else {
           texture.setTextureFromArray( width, height, null );
         }

--- a/src/GLCat.ts
+++ b/src/GLCat.ts
@@ -527,7 +527,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
       samples = 4,
       isFloat = false,
       depthFormat = this.preferredDepthFormat,
-      fallback = true
+      fallbackWebGL1 = true
     } = {}
   ): GLCatFramebuffer<TContext> {
     const gl = this.__gl;
@@ -570,7 +570,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
         renderbufferDepth?.dispose();
         throw e;
       }
-    } else if ( fallback ) {
+    } else if ( fallbackWebGL1 ) {
       return this.lazyFramebuffer( width, height, { isFloat } );
     } else {
       throw GLCatErrors.WebGL2ExclusiveError;


### PR DESCRIPTION
- ✨ use new parameters of `GLCatTexture.setTextureFromArray` wisely
- 🚨 `GLCatTexture.setTextureFromFloatArray` is gone
- 🚨 `fallback` option of `lazyMultisampleFramebuffer` is renamed to `fallbackWebGL1`
