### PR TITLE
GLCatRenderbuffer: fix default format value for renderbufferStorageMultisample

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,5 +17,8 @@ module.exports = {
   "collectCoverageFrom": [
     "**/*.{ts,tsx}",
     "!**/tests/**"
+  ],
+  "setupFilesAfterEnv": [
+    "./jest.setup.ts"
   ]
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,4 @@
+/* eslint-disable no-undef, @typescript-eslint/ban-ts-ignore */
+
+// @ts-ignore
+global.WebGL2RenderingContext = undefined;

--- a/src/GLCat.ts
+++ b/src/GLCat.ts
@@ -133,7 +133,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
     gl.enable( GL_BLEND );
     gl.blendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 
-    if ( this.__gl instanceof WebGL2RenderingContext ) {
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
       this.preferredDepthFormat = GL_DEPTH_COMPONENT24;
     } else {
       this.preferredDepthFormat = GL_DEPTH_COMPONENT16;
@@ -381,7 +381,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
   public createVertexArray(): GLCatVertexArray<TContext> {
     const gl = this.__gl;
 
-    if ( gl instanceof WebGL2RenderingContext ) {
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
       const vertexArray = GLCat.throwIfNull( gl.createVertexArray() );
 
       return new GLCatVertexArray( this, vertexArray as any );
@@ -402,7 +402,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
   public rawBindVertexArray( array: GLCatVertexArrayRawType<TContext> | null ): void {
     const gl = this.__gl;
 
-    if ( gl instanceof WebGL2RenderingContext ) {
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
       gl.bindVertexArray( array );
     } else {
       const ext = this.getExtension( 'OES_vertex_array_object', true );
@@ -563,7 +563,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
   ): GLCatFramebuffer<TContext> {
     const gl = this.__gl;
 
-    if ( gl instanceof WebGL2RenderingContext ) {
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
       let texture: GLCatTexture<TContext> | undefined;
       let renderbufferDepth: GLCatRenderbuffer<TContext> | undefined;
       let renderbufferColor: GLCatRenderbuffer<TContext> | undefined;
@@ -674,7 +674,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
   public rawDrawBuffers( buffers: GLenum[] ): void {
     const gl = this.__gl;
 
-    if ( gl instanceof WebGL2RenderingContext ) {
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
       gl.drawBuffers( buffers );
     } else {
       const ext = this.getExtension( 'WEBGL_draw_buffers' );
@@ -720,7 +720,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
   ): void {
     const { gl } = this;
 
-    if ( gl instanceof WebGL2RenderingContext ) {
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
       gl.drawArraysInstanced( mode, first, count, primcount );
     } else {
       const ext = this.getExtension( 'ANGLE_instanced_arrays', true );
@@ -740,7 +740,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
   ): void {
     const { gl } = this;
 
-    if ( gl instanceof WebGL2RenderingContext ) {
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
       gl.drawElementsInstanced( mode, count, type, offset, instanceCount );
     } else {
       const ext = this.getExtension( 'ANGLE_instanced_arrays', true );
@@ -780,7 +780,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
   ): void {
     const gl = this.__gl;
 
-    if ( gl instanceof WebGL2RenderingContext ) {
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
       gl.bindFramebuffer( GL_READ_FRAMEBUFFER, src?.raw ?? null );
       gl.bindFramebuffer( GL_DRAW_FRAMEBUFFER, dst?.raw ?? null );
       gl.blitFramebuffer(

--- a/src/GLCat.ts
+++ b/src/GLCat.ts
@@ -1,4 +1,4 @@
-import { GL_ARRAY_BUFFER, GL_BLEND, GL_COLOR_ATTACHMENT0, GL_COLOR_BUFFER_BIT, GL_DEPTH24_STENCIL8, GL_DEPTH_ATTACHMENT, GL_DEPTH_BUFFER_BIT, GL_DEPTH_COMPONENT16, GL_DEPTH_TEST, GL_DRAW_FRAMEBUFFER, GL_ELEMENT_ARRAY_BUFFER, GL_FLOAT, GL_FRAGMENT_SHADER, GL_FRAMEBUFFER, GL_LEQUAL, GL_MAX_DRAW_BUFFERS, GL_NEAREST, GL_ONE_MINUS_SRC_ALPHA, GL_READ_FRAMEBUFFER, GL_RENDERBUFFER, GL_RGBA, GL_RGBA32F, GL_RGBA8, GL_SRC_ALPHA, GL_TEXTURE_2D, GL_TEXTURE_CUBE_MAP, GL_VERTEX_SHADER } from './GLConstants';
+import { GL_ARRAY_BUFFER, GL_BLEND, GL_COLOR_ATTACHMENT0, GL_COLOR_BUFFER_BIT, GL_DEPTH_ATTACHMENT, GL_DEPTH_BUFFER_BIT, GL_DEPTH_COMPONENT16, GL_DEPTH_COMPONENT24, GL_DEPTH_TEST, GL_DRAW_FRAMEBUFFER, GL_ELEMENT_ARRAY_BUFFER, GL_FLOAT, GL_FRAGMENT_SHADER, GL_FRAMEBUFFER, GL_LEQUAL, GL_MAX_DRAW_BUFFERS, GL_NEAREST, GL_ONE_MINUS_SRC_ALPHA, GL_READ_FRAMEBUFFER, GL_RENDERBUFFER, GL_RGBA, GL_RGBA32F, GL_RGBA8, GL_SRC_ALPHA, GL_TEXTURE_2D, GL_TEXTURE_CUBE_MAP, GL_VERTEX_SHADER } from './GLConstants';
 import { BindHelper } from './utils/BindHelper';
 import { GLCatBuffer } from './GLCatBuffer';
 import { GLCatErrors } from './GLCatErrors';
@@ -30,19 +30,7 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
 
   public preferredMultisampleSamples = 4;
 
-  private __preferredDepthFormat: GLenum | null = null;
-  public get preferredDepthFormat(): GLenum {
-    if ( this.__preferredDepthFormat !== null ) {
-      return this.__preferredDepthFormat;
-    } else if ( this.__gl instanceof WebGL2RenderingContext ) {
-      return GL_DEPTH24_STENCIL8;
-    } else {
-      return GL_DEPTH_COMPONENT16;
-    }
-  }
-  public set preferredDepthFormat( format: GLenum ) {
-    this.__preferredDepthFormat = format;
-  }
+  public preferredDepthFormat: GLenum; // will be set in constructor
 
   private __gl: TContext;
 
@@ -144,6 +132,12 @@ export class GLCat<TContext extends WebGLRenderingContext | WebGL2RenderingConte
     gl.depthFunc( GL_LEQUAL );
     gl.enable( GL_BLEND );
     gl.blendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
+
+    if ( this.__gl instanceof WebGL2RenderingContext ) {
+      this.preferredDepthFormat = GL_DEPTH_COMPONENT24;
+    } else {
+      this.preferredDepthFormat = GL_DEPTH_COMPONENT16;
+    }
   }
 
   /**

--- a/src/GLCatProgram.ts
+++ b/src/GLCatProgram.ts
@@ -159,7 +159,7 @@ export class GLCatProgram<TContext extends WebGLRenderingContext | WebGL2Renderi
       gl.enableVertexAttribArray( location );
       gl.vertexAttribPointer( location, size, type, false, stride, offset );
 
-      if ( gl instanceof WebGL2RenderingContext ) {
+      if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
         gl.vertexAttribDivisor( location, divisor );
       } else {
         const ext = this.__glCat.getExtension( 'ANGLE_instanced_arrays' );

--- a/src/GLCatRenderbuffer.ts
+++ b/src/GLCatRenderbuffer.ts
@@ -88,7 +88,7 @@ export class GLCatRenderbuffer<TContext extends WebGLRenderingContext | WebGL2Re
     const { gl } = this.__glCat;
 
     this.__glCat.bindRenderbuffer( this, () => {
-      if ( gl instanceof WebGL2RenderingContext ) {
+      if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
         gl.renderbufferStorageMultisample( GL_RENDERBUFFER, samples, format, width, height );
       } else {
         if ( fallbackWebGL1 ) {

--- a/src/GLCatRenderbuffer.ts
+++ b/src/GLCatRenderbuffer.ts
@@ -1,6 +1,6 @@
-import { GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER } from './GLConstants';
 import type { GLCat } from './GLCat';
 import { GLCatErrors } from './GLCatErrors';
+import { GL_RENDERBUFFER } from './GLConstants';
 
 /**
  * It's a WebGLRenderbuffer.
@@ -81,7 +81,7 @@ export class GLCatRenderbuffer<TContext extends WebGLRenderingContext | WebGL2Re
     height: number,
     {
       samples = this.__glCat.preferredMultisampleSamples,
-      format = GL_DEPTH_ATTACHMENT,
+      format = this.__glCat.preferredDepthFormat,
       fallbackWebGL1 = true
     } = {}
   ): void {

--- a/src/GLCatTexture.ts
+++ b/src/GLCatTexture.ts
@@ -98,7 +98,7 @@ export class GLCatTexture<TContext extends WebGLRenderingContext | WebGL2Renderi
   ): void {
     const { gl } = this.__glCat;
 
-    if ( gl instanceof WebGL2RenderingContext ) {
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
       this.__glCat.bindTexture2D( this, () => {
         gl.texStorage2D( target, level, format, width, height );
       } );
@@ -162,7 +162,7 @@ export class GLCatTexture<TContext extends WebGLRenderingContext | WebGL2Renderi
     const { gl } = this.__glCat;
 
     let iformat = internalformat;
-    if ( !( gl instanceof WebGL2RenderingContext ) ) {
+    if ( !( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) ) {
       if ( type === GL_HALF_FLOAT ) {
         this.__glCat.getExtension( 'OES_texture_half_float', true );
         this.__glCat.getExtension( 'OES_texture_half_float_linear' );

--- a/src/GLCatVertexArray.ts
+++ b/src/GLCatVertexArray.ts
@@ -37,7 +37,7 @@ export class GLCatVertexArray<TContext extends WebGLRenderingContext | WebGL2Ren
   public dispose(): void {
     const { gl } = this.__glCat;
 
-    if ( gl instanceof WebGL2RenderingContext ) {
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
       gl.deleteVertexArray( this.__vertexArray );
     } else {
       const ext = this.__glCat.getExtension( 'OES_vertex_array_object', true );
@@ -64,7 +64,7 @@ export class GLCatVertexArray<TContext extends WebGLRenderingContext | WebGL2Ren
       gl.enableVertexAttribArray( location );
       gl.vertexAttribPointer( location, size, type, false, stride, offset );
 
-      if ( gl instanceof WebGL2RenderingContext ) {
+      if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
         gl.vertexAttribDivisor( location, divisor );
       } else {
         const ext = this.__glCat.getExtension( 'ANGLE_instanced_arrays' );


### PR DESCRIPTION
+ changed default depth format for webgl2

that was a dumb mistake
