### PR TITLE
BREAKING feature: implement transform feedback support

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -13,5 +13,6 @@
     <a href="./webgl2_vao.html">webgl2_vao</a> : Plane using VAO<br />
     <a href="./webgl2_offscreen_msaa.html">webgl2_offscreen_msaa</a> : Multisample framebuffer<br />
     <a href="./webgl2_mrt.html">webgl2_mrt</a> : Multiple render target<br />
+    <a href="./webgl2_transform_feedback.html">webgl2_transform_feedback</a> : Use transform feedback<br />
   </p>
 </body>

--- a/examples/webgl2_transform_feedback.html
+++ b/examples/webgl2_transform_feedback.html
@@ -1,0 +1,76 @@
+<body>
+  <canvas id="canvas" width=1280 height=720></canvas>
+</body>
+
+<script type="module">
+  import { GLCat } from '../dist/glcat.module.js';
+  import {
+    TRIANGLE_STRIP_QUAD,
+    TRIANGLE_STRIP_QUAD_UV,
+  } from 'https://unpkg.com/@fms-cat/experimental@0.4.1/dist/fms-cat-experimental.module.min.js';
+
+  const canvas = document.getElementById( 'canvas' );
+  const gl = canvas.getContext( 'webgl2' );
+  const glCat = new GLCat( gl );
+
+  const vboIn = glCat.createBuffer();
+  vboIn.setVertexbuffer( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ) );
+
+  const vboFeedbackA = glCat.createBuffer();
+  vboFeedbackA.setVertexbuffer( 6 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_COPY );
+
+  const vboFeedbackB = glCat.createBuffer();
+  vboFeedbackB.setVertexbuffer( 6 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_COPY );
+
+  const transformFeedback = glCat.createTransformFeedback();
+  transformFeedback.bindBuffer( 0, vboFeedbackA );
+  transformFeedback.bindBuffer( 1, vboFeedbackB );
+
+  const shaderVert = `#version 300 es
+
+in float aIn;
+out float vOutA;
+out float vOutB;
+
+void main() {
+  vOutA = aIn * 2.0;
+  vOutB = aIn * 3.0;
+}
+`;
+
+  const shaderFrag = `#version 300 es
+
+  void main() {
+    discard;
+  }
+  `;
+
+  const program = glCat.lazyProgram(
+    shaderVert,
+    shaderFrag,
+    { transformFeedbackVaryings: [ 'vOutA', 'vOutB' ] }
+  );
+
+  program.attribute( 'aIn', vboIn, 1 );
+
+  gl.enable( gl.RASTERIZER_DISCARD );
+  glCat.useProgram( program, () => {
+    glCat.bindTransformFeedback( transformFeedback, () => {
+      gl.beginTransformFeedback( gl.POINTS );
+      gl.drawArrays( gl.POINTS, 0, 6 );
+      gl.endTransformFeedback();
+    } );
+  } );
+
+  const arrayFeedbackA = new Float32Array( 6 );
+  glCat.bindVertexBuffer( vboFeedbackA, () => {
+    gl.getBufferSubData( gl.ARRAY_BUFFER, 0, arrayFeedbackA );
+  } );
+  console.log( arrayFeedbackA );
+
+  const arrayFeedbackB = new Float32Array( 6 );
+  glCat.bindVertexBuffer( vboFeedbackB, () => {
+    gl.getBufferSubData( gl.ARRAY_BUFFER, 0, arrayFeedbackB );
+  } );
+  console.log( arrayFeedbackB );
+</script>

--- a/src/GLCatTransformFeedback.ts
+++ b/src/GLCatTransformFeedback.ts
@@ -1,0 +1,58 @@
+import type { GLCat } from './GLCat';
+import { GLCatBuffer } from './GLCatBuffer';
+
+/**
+ * It's a WebGLTransformFeedback.
+ */
+export class GLCatTransformFeedback<
+  TContext extends WebGLRenderingContext | WebGL2RenderingContext
+> {
+  private __glCat: GLCat<TContext>;
+  private __transformFeedback: WebGLTransformFeedback;
+
+  /**
+   * Its own transform feedback.
+   */
+  public get transformFeedback(): WebGLTransformFeedback {
+    return this.__transformFeedback;
+  }
+
+  /**
+   * Its own transform feedback. Shorter than {@link transformFeedback}.
+   */
+  public get raw(): WebGLTransformFeedback {
+    return this.__transformFeedback;
+  }
+
+  /**
+   * Create a new GLCatTransformFeedback instance.
+   */
+  public constructor( glCat: GLCat<TContext>, transformFeedback: WebGLTransformFeedback ) {
+    this.__glCat = glCat;
+    this.__transformFeedback = transformFeedback;
+  }
+
+  /**
+   * Dispose the transform feedback.
+   */
+  public dispose(): void {
+    const { gl } = this.__glCat;
+
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
+      gl.deleteTransformFeedback( this.__transformFeedback );
+    }
+  }
+
+  /**
+   * Bind a buffer to this transform feedback.
+   */
+  public bindBuffer( index: GLuint, buffer: GLCatBuffer<TContext> | null ): void {
+    const { gl } = this.__glCat;
+
+    if ( WebGL2RenderingContext && gl instanceof WebGL2RenderingContext ) {
+      this.__glCat.bindTransformFeedback( this, () => {
+        gl.bindBufferBase( gl.TRANSFORM_FEEDBACK_BUFFER, index, buffer?.buffer ?? null );
+      } );
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './GLCatProgram';
 export * from './GLCatRenderbuffer';
 export * from './GLCatShader';
 export * from './GLCatTexture';
+export * from './GLCatTransformFeedback';
 export * from './GLCatVertexArray';
 
 import { GLCat } from './GLCat';

--- a/src/tests/GLCatProgram.test.ts
+++ b/src/tests/GLCatProgram.test.ts
@@ -42,7 +42,7 @@ describe( 'GLCatProgram', () => {
 
   describe( 'link', () => {
     it ( 'should link the WebGLProgram successfully', () => {
-      program.link( quadVert, uvFrag );
+      program.link( [ quadVert, uvFrag ] );
       expect( program.isLinked ).toBe( true );
     } );
   } );


### PR DESCRIPTION
- 🚨 `GLCatProgram.link` / `GLCatProgram.linkAsync` : the parameter `shaders` was formerly a spread array of `GLCatShader` , now it's an actual array of `GLCatShader`.
- ✨ Transform feedback support
    - New class: `GLCatTransformFeedback`
    - Now you can specify `transformFeedbackVaryings` and `transformFeedbackBufferMode` via `options` parameter when you link a program
- 📝 Add an example: `webgl2_transform_feedback.html`